### PR TITLE
Add token rotation service tests

### DIFF
--- a/src/adapter/persistence/repository/RefreshTokenRepository.ts
+++ b/src/adapter/persistence/repository/RefreshTokenRepository.ts
@@ -1,4 +1,4 @@
-import { Repository, LessThan, DeleteResult } from 'typeorm';
+import { Repository, LessThan } from 'typeorm';
 import { Service } from 'typedi';
 import { RefreshToken } from 'entity/RefreshToken';
 import { RefreshTokenEntity } from '../entity/RefreshTokenEntity';

--- a/src/adapter/security/TokenService.ts
+++ b/src/adapter/security/TokenService.ts
@@ -110,7 +110,10 @@ export class TokenService implements TokenServiceInterface {
     }
 
     try {
-      const payload = jwt.verify(token, this.JWT_REFRESH_SECRET) as any;
+      const payload = jwt.verify(
+        token,
+        this.JWT_REFRESH_SECRET,
+      ) as jwt.JwtPayload;
 
       if (!payload.userGuid) {
         throw new Error('Invalid refresh token payload');

--- a/src/application/login/LoginService.test.ts
+++ b/src/application/login/LoginService.test.ts
@@ -11,7 +11,6 @@ import { LoginDto } from 'application/login/dto/LoginDto';
 import { UnauthorizedException } from 'shared/exception/UnauthorizedException';
 import { User } from 'entity/User';
 import { UserAndPassword } from 'entity/UserAndPassword';
-import { TokenPair } from 'entity/TokenPair';
 import { NotFoundException } from 'shared/exception/NotFoundException';
 import {
   LoginRepositoryInterfaceToken,

--- a/src/application/tokenRotation/TokenRotationService.test.ts
+++ b/src/application/tokenRotation/TokenRotationService.test.ts
@@ -1,0 +1,191 @@
+import 'reflect-metadata';
+import { Container } from 'typedi';
+import { TokenRotationService } from './TokenRotationService';
+import { TokenServiceInterface } from 'application/shared/port/TokenServiceInterface';
+import { RefreshTokenRepositoryInterface } from 'application/shared/port/RefreshTokenRepositoryInterface';
+import { UserRepositoryInterface } from 'application/user/port/UserRepositoryInterface';
+import { RefreshToken } from 'entity/RefreshToken';
+import { User, UserStatus } from 'entity/User';
+import { UnauthorizedException } from 'shared/exception/UnauthorizedException';
+import { NotFoundException } from 'shared/exception/NotFoundException';
+import {
+  TokenServiceInterfaceToken,
+  RefreshTokenRepositoryInterfaceToken,
+  UserRepositoryInterfaceToken,
+} from 'di/tokens';
+
+describe('TokenRotationService', () => {
+  let tokenRotationService: TokenRotationService;
+  let tokenService: TokenServiceInterface;
+  let refreshTokenRepository: RefreshTokenRepositoryInterface;
+  let userRepository: UserRepositoryInterface;
+
+  beforeAll(() => {
+    tokenService = {
+      verifyRefreshToken: jest.fn(),
+      generateTokenPair: jest.fn(),
+      generateToken: jest.fn(),
+      verifyToken: jest.fn(),
+      generateRefreshToken: jest.fn(),
+    } as unknown as TokenServiceInterface;
+
+    refreshTokenRepository = {
+      findByToken: jest.fn(),
+      deleteByToken: jest.fn(),
+      save: jest.fn(),
+      deleteByUserGuid: jest.fn(),
+      findByUserGuid: jest.fn(),
+      deleteExpiredTokens: jest.fn(),
+    } as unknown as RefreshTokenRepositoryInterface;
+
+    userRepository = {
+      findByGuid: jest.fn(),
+      findAll: jest.fn(),
+      updateUser: jest.fn(),
+      deleteUser: jest.fn(),
+      checkIfUserExists: jest.fn(),
+    } as unknown as UserRepositoryInterface;
+
+    Container.set(TokenServiceInterfaceToken, tokenService);
+    Container.set(RefreshTokenRepositoryInterfaceToken, refreshTokenRepository);
+    Container.set(UserRepositoryInterfaceToken, userRepository);
+
+    tokenRotationService = Container.get(TokenRotationService);
+  });
+
+  afterAll(() => {
+    Container.reset();
+  });
+
+  it('should rotate tokens when refresh token is valid', async () => {
+    const userGuid = 'user-guid';
+    const refreshTokenString = 'valid-refresh-token';
+    const existingToken = new RefreshToken(
+      'id',
+      userGuid,
+      refreshTokenString,
+      new Date(Date.now() + 10000),
+      new Date(),
+    );
+    const user = new User(userGuid, 'username', false, false, 'Test');
+    const tokenPairResult = {
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      accessTokenExpiresIn: 3600,
+      refreshTokenExpiresIn: 7200,
+    };
+
+    (tokenService.verifyRefreshToken as jest.Mock).mockReturnValue({
+      userGuid,
+    });
+    (refreshTokenRepository.findByToken as jest.Mock).mockResolvedValue(
+      existingToken,
+    );
+    (userRepository.findByGuid as jest.Mock).mockResolvedValue(user);
+    (tokenService.generateTokenPair as jest.Mock).mockReturnValue(
+      tokenPairResult,
+    );
+    (refreshTokenRepository.deleteByToken as jest.Mock).mockResolvedValue(true);
+    (refreshTokenRepository.save as jest.Mock).mockResolvedValue(existingToken);
+
+    const pair = await tokenRotationService.rotateTokens(refreshTokenString);
+
+    expect(pair.accessToken).toBe('access');
+    expect(pair.refreshToken).toBe('refresh');
+    expect(tokenService.verifyRefreshToken).toHaveBeenCalledWith(
+      refreshTokenString,
+    );
+    expect(refreshTokenRepository.findByToken).toHaveBeenCalledWith(
+      refreshTokenString,
+    );
+    expect(refreshTokenRepository.deleteByToken).toHaveBeenCalledWith(
+      refreshTokenString,
+    );
+    expect(tokenService.generateTokenPair).toHaveBeenCalledWith(user);
+    expect(refreshTokenRepository.save).toHaveBeenCalled();
+  });
+
+  it('should throw UnauthorizedException if refresh token not found', async () => {
+    (tokenService.verifyRefreshToken as jest.Mock).mockReturnValue({
+      userGuid: 'uid',
+    });
+    (refreshTokenRepository.findByToken as jest.Mock).mockResolvedValue(null);
+
+    await expect(tokenRotationService.rotateTokens('missing')).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('should throw UnauthorizedException if refresh token expired', async () => {
+    const expired = new RefreshToken(
+      'id',
+      'uid',
+      'token',
+      new Date(Date.now() - 1000),
+      new Date(),
+    );
+    (tokenService.verifyRefreshToken as jest.Mock).mockReturnValue({
+      userGuid: 'uid',
+    });
+    (refreshTokenRepository.findByToken as jest.Mock).mockResolvedValue(
+      expired,
+    );
+
+    await expect(tokenRotationService.rotateTokens('token')).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('should throw NotFoundException if user not found', async () => {
+    const valid = new RefreshToken(
+      'id',
+      'uid',
+      'token',
+      new Date(Date.now() + 1000),
+      new Date(),
+    );
+    (tokenService.verifyRefreshToken as jest.Mock).mockReturnValue({
+      userGuid: 'uid',
+    });
+    (refreshTokenRepository.findByToken as jest.Mock).mockResolvedValue(valid);
+    (userRepository.findByGuid as jest.Mock).mockResolvedValue(undefined);
+
+    await expect(tokenRotationService.rotateTokens('token')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('should throw UnauthorizedException if user is inactive', async () => {
+    const valid = new RefreshToken(
+      'id',
+      'uid',
+      'token',
+      new Date(Date.now() + 1000),
+      new Date(),
+    );
+    const inactiveUser = new User(
+      'uid',
+      'username',
+      false,
+      false,
+      'Test',
+      'User',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      UserStatus.BLOCKED,
+    );
+
+    (tokenService.verifyRefreshToken as jest.Mock).mockReturnValue({
+      userGuid: 'uid',
+    });
+    (refreshTokenRepository.findByToken as jest.Mock).mockResolvedValue(valid);
+    (userRepository.findByGuid as jest.Mock).mockResolvedValue(inactiveUser);
+
+    await expect(tokenRotationService.rotateTokens('token')).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+});

--- a/src/presentation/web/controllers/refreshToken/RefreshTokenDto.ts
+++ b/src/presentation/web/controllers/refreshToken/RefreshTokenDto.ts
@@ -12,7 +12,7 @@ export class RefreshTokenDto {
    * Creates a new RefreshTokenDto instance from request body
    * @param body Request body containing refresh token
    */
-  constructor(body: any) {
+  constructor(body: { refreshToken: string }) {
     this.refreshToken = body.refreshToken;
   }
 }

--- a/tests/me.test.ts
+++ b/tests/me.test.ts
@@ -3,10 +3,7 @@ import jwt from 'jsonwebtoken';
 import app from 'presentation/web/server';
 import { AppDataSource } from 'adapter/persistence/data-source';
 import { UserEntity } from 'adapter/persistence/entity/UserEntity';
-import {
-  TokenResult,
-  TokenServiceInterface,
-} from 'application/shared/port/TokenServiceInterface';
+import { TokenServiceInterface } from 'application/shared/port/TokenServiceInterface';
 import { TokenService } from 'adapter/security/TokenService';
 
 describe('GET /v1/me', () => {


### PR DESCRIPTION
## Summary
- add unit tests for `TokenRotationService`
- fix lint errors in repository
- minor typing fixes in DTOs and services

## Testing
- `yarn lint`
- `yarn format`
- `yarn build`
- `yarn test:unit`

------
https://chatgpt.com/codex/tasks/task_e_684ca3e7a7d48327a74732fac2f3fdc5